### PR TITLE
feat : transcipt title change

### DIFF
--- a/src/components/Transcript.jsx
+++ b/src/components/Transcript.jsx
@@ -175,7 +175,7 @@ export default function Transcript({ playerRef, currentTime }) {
                 onWheel={lockAll}
                 onTouchMove={lockAll}
             >
-                <h3 ref={headerRef}>文字起こし</h3>
+                <h3 ref={headerRef}>{expanded !== -1 ? 'ノート' : '文字起こし'}</h3>
                 {captions.map((caption, i) => (
                     <div
                         className='caption-container'


### PR DESCRIPTION
<!-- 請先閱讀我們手冊的 [How to PR](https://hackmd.io/@sessatakuma/pr_template#How-to-PR) 章節 -->
<!-- 記得修改PR標題成 conventional commit 之標題格式  -->

### 目的
讓文字起こし的標題在筆記模式顯示ノート

### 方法／實作說明
依據expanded解鎖狀態判斷標題顯示字樣

- 主要修改：
  - Transcript.jsx
- 關鍵實作：
 

### 關聯 Issue


### 附註


- TODO：
  -

如果做了UI的更動請附上before/after截圖

before:
<img width="944" height="244" alt="螢幕擷取畫面 2025-11-14 101156" src="https://github.com/user-attachments/assets/089286d0-841f-4b74-9f3a-2c4e3cbb9dad" />

after:
<img width="960" height="239" alt="image" src="https://github.com/user-attachments/assets/163a493d-879f-4e3d-a086-6afc6281c539" />
